### PR TITLE
WEB 201 - Extraia o CSS em um arquivo separado

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,6 +23,9 @@ engines:
       - php
   eslint:
     enabled: true
+    checks:
+      global-require:
+        enabled: false
   fixme:
     enabled: true
 ratings:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "assets-webpack-plugin": "^3.5.1",
     "cross-env": "^3.2.3",
+    "extract-text-webpack-plugin": "^2.1.0",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.17.1"
   },

--- a/src/public/styles/main.less
+++ b/src/public/styles/main.less
@@ -1,3 +1,2 @@
-@import "~semantic-ui/dist/semantic.min.css";
 @import "main.css";
 @import "App/app";

--- a/src/server/express.js
+++ b/src/server/express.js
@@ -21,6 +21,8 @@ const renderFullPage = (assets) => {
             <meta charSet="utf-8" />
             <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <link rel='stylesheet' href='${assets.vendor.css}'/>
+            <link rel='stylesheet' href='${assets.bundle.css}'/>
           </head>
           <body>
             <div id="root"></div>
@@ -36,13 +38,13 @@ server.get('*', (req, res) => {
 
         const getAssetConcat = (Assets, key) => {
             Assets.filter(asset => {
-                if (asset.endsWith('.js')) {
+                if (asset.endsWith('.js') || asset.endsWith('.css')) {
                     asset = '/build/public/'.concat(asset);
+                    let Asset = asset.endsWith('.js') ? { js: { value: asset }} : { css: { value: asset }};
                     let Path = path.parse(path.parse(asset).name);
-                    if (Path.base === Path.name && !Path.ext){
-                        assets[key] = {
-                            js: asset
-                        }
+                    if (Path.base === Path.name && !Path.ext) {
+                        if (!assets[key]) assets[key] = Object.create(Object.prototype);
+                        assets[key] = Object.create(assets[key], Asset);
                     }
                 }
             });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,6 +2,7 @@
 var path = require('path');
 var webpack = require('webpack');
 
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const OccurrenceOrderPlugin = new webpack.optimize.OccurrenceOrderPlugin();
 
 module.exports = {
@@ -15,7 +16,8 @@ module.exports = {
             './src/public/styles/main.less'
         ],
         vendor: [
-            'aphrodite' // Stylesheet Javascript for styles components
+            'aphrodite', // Stylesheet Javascript for styles components
+            'semantic-ui/dist/semantic.min.css'
         ]
     },
     output: {
@@ -35,7 +37,8 @@ module.exports = {
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('development'),
             '__DEV__': true
-        })
+        }),
+        new ExtractTextPlugin("[name].css")
     ],
     module: {
         rules: [{
@@ -44,19 +47,21 @@ module.exports = {
             use: 'babel-loader',
             include: path.join(__dirname, 'src/app')
         }, {
-            test: /\.less$/,
-            use: [
-                'style-loader',
-                {
+            test: /\.(less|css)$/,
+            use: ExtractTextPlugin.extract({
+                fallback: 'style-loader',
+                use: [{
                     loader: 'css-loader',
                     options: {
-                        importLoaders: 1
+                        sourceMap: true
                     }
                 }, {
-                    loader: 'less-loader'
-                }
-            ],
-            include: path.join(__dirname, 'src/public/styles')
+                    loader: 'less-loader',
+                    options: {
+                        sourceMap: true
+                    }
+                }]
+            })
         }, {
             test: /\.(png|woff|woff2|eot|ttf|svg)$/,
             use: 'url-loader'


### PR DESCRIPTION
## #8 Extraia o CSS em um arquivo separado

Atualmente, o CSS da aplicação está incluído no bundle.js.
Entretanto, nossos usuários começaram a comentar sobre a aplicação estar
sem nenhum estilo quando inicia, e nós gostaríamos então de separar o CSS em outro arquivo.
Por favor, integre o plugin extract-text-webpack-plugin na configuração do webpack
e carregue o arquivo CSS separamente do bundle javascript.

Como estamos usando server-rendering com node.js e express nossa implementação possibilitou modular o bundle do webpack para a nossa aplicação. 