### PR TITLE
WEB-102 - Adicionar um todo item causa perca de foco no text field

### DIFF
--- a/src/app/components/Input/Input.js
+++ b/src/app/components/Input/Input.js
@@ -7,9 +7,11 @@ import styles from './../../styles';
 
 export class InputToDoItemComponent {
     static addTodoItem (event) {
-        const todoInput = document.getElementById('todoInput');
-        todos.dispatch(addTodo(todoInput.value));
+        const todoInput = document.getElementById('todoInput').value;
+
+        todos.dispatch(addTodo(todoInput));
         event.stopPropagation();
+        document.getElementById('todoInput').focus();
     }
 
     static addTodoItemWithEnter (event) {

--- a/src/app/components/Input/Input.test.js
+++ b/src/app/components/Input/Input.test.js
@@ -10,14 +10,19 @@ const event = {
         matches: selector => true,
         getAttribute: attribute => '1'
     },
-    stopPropagation: () => true,
-    preventDefault: () => true,
+    stopPropagation: () => {},
+    preventDefault: () => {},
     which: 13,
     key: 'Enter'
 };
 
 global.document = {
-    getElementById: id => { return {value: `data ${id}`} }
+    getElementById: id => {
+        return {
+            value: `data ${id}`,
+            focus: () => {}
+        }
+    }
 };
 
 describe('Component: InputToDoItemComponent', () => {
@@ -60,6 +65,7 @@ describe('Component: InputToDoItemComponent', () => {
     describe('static addTodoItem () =>', () => {
         test('should dispatch new state todo items with new todo item added', () => {
             const mockAddTodo = jest.fn(addTodo);
+
             spyOn(todos, 'dispatch');
             spyOn(event, 'stopPropagation');
 

--- a/src/app/events.test.js
+++ b/src/app/events.test.js
@@ -17,7 +17,12 @@ global.document = {
     body: {
         addEventListener: (eventName, listener) => listener(event)
     },
-    getElementById: id => { return {value: `data input ${id}`} }
+    getElementById: id => {
+        return {
+            value: `data input ${id}`,
+            focus: () => {}
+        }
+    }
 };
 
 describe('Events: registerEventHandlers', () => {


### PR DESCRIPTION
## #2 Adicionar um todo item causa perca de foco no text field

Como nós habilitamos a tecla `enter` para adicionar um todo item, nossos usuários
notaram que ao adicionar, o text field perde o foco e eles precisam clicar manualmente no input
para voltar o foco para ele.

Por favor, garanta que ao adicionar um todo item, o foco irá voltar (ou manter-se) ao text field.