### PR TITLE
WEB - 103 - Adicione um filtro de status como TESTE

### DIFF
--- a/.docs/tasks.md
+++ b/.docs/tasks.md
@@ -18,9 +18,9 @@ Nós gostaríamos de poder adicionar um ToDO item, usando a tecla `enter`
 
  Por favor, garanta que ao adicionar um ToDo item, o foco irá voltar (ou manter-se) ao text field.
 
-### WEB-103
+### ~~WEB-103~~
 
-- [ ] Adicione um filtro de status como TESTE
+- [x] Adicione um filtro de status como TESTE
 
 Como um usuário, eu quero ter uma opção para esconder itens que não me interessam
 baseado nos seus status.

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -1,14 +1,13 @@
-
-export function toggleTodoState(id) {
+export const toggleTodoState = (id) => {
     return {
         type: 'TODO_TOGGLE_DONE',
         id
     };
-}
+};
 
-export function addTodo(text) {
+export const addTodo = (text) => {
     return {
         type: 'ADD_TODO',
         text
     }
-}
+};

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -1,5 +1,7 @@
 import { isEnabled } from './../lib/feature';
+
 import Component from  './View';
+
 import TitleComponent from './Title/Title';
 import InputToDoItemComponent from './Input/Input';
 import TodoListComponent from './Todo/TodoList';
@@ -11,27 +13,21 @@ export default class AppComponent extends Component {
     }
 
     renderApp (el, state) {
-        this.render(el, this.renderAddToDoItemAt(isEnabled('renderBottom'), state));
+        this.render(el, AppComponent.renderAddToDoItemAt(isEnabled('renderBottom'), state));
     }
 
-    renderAddToDoItemAt (isEnabled, state) {
-        let App;
+    static joinComponents (Components) {
+        return Components.join('\n');
+    }
+
+    static renderAddToDoItemAt (isEnabled, state) {
+        let Components = [TitleComponent.renderTitle(), FilterComponent.renderFilter(state.filters)];
         if (isEnabled) {
-            App = String.prototype.concat(
-                TitleComponent.renderTitle(),
-                FilterComponent.renderFilter(),
-                TodoListComponent.renderToDoItems(state.todos),
-                InputToDoItemComponent.renderInput()
-            );
+            Components.push(TodoListComponent.renderToDoItems(state.todos), InputToDoItemComponent.renderInput());
         } else {
-            App = String.prototype.concat(
-                TitleComponent.renderTitle(),
-                FilterComponent.renderFilter(),
-                InputToDoItemComponent.renderInput(),
-                TodoListComponent.renderToDoItems(state.todos)
-            );
+            Components.push(InputToDoItemComponent.renderInput(), TodoListComponent.renderToDoItems(state.todos));
         }
 
-        return `<div id="app">${App}</div>`;
+        return `<div id="app">${AppComponent.joinComponents(Components)}</div>`;
     }
 }

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -1,8 +1,9 @@
 import { isEnabled } from './../lib/feature';
 import Component from  './View';
-import { TitleComponent } from './Title/Title';
-import { InputToDoItemComponent } from './Input/Input';
-import { TodoListComponent } from './Todo/TodoList';
+import TitleComponent from './Title/Title';
+import InputToDoItemComponent from './Input/Input';
+import TodoListComponent from './Todo/TodoList';
+import FilterComponent from './Filter/Filter';
 
 export default class AppComponent extends Component {
     constructor () {
@@ -10,22 +11,24 @@ export default class AppComponent extends Component {
     }
 
     renderApp (el, state) {
-        this.render(el, this.renderAddToDoItemAt(isEnabled('renderBottom'), state.todos));
+        this.render(el, this.renderAddToDoItemAt(isEnabled('renderBottom'), state));
     }
 
-    renderAddToDoItemAt (isEnabled, TODOS) {
+    renderAddToDoItemAt (isEnabled, state) {
         let App;
         if (isEnabled) {
             App = String.prototype.concat(
                 TitleComponent.renderTitle(),
-                TodoListComponent.renderToDoItems(TODOS),
+                FilterComponent.renderFilter(),
+                TodoListComponent.renderToDoItems(state.todos),
                 InputToDoItemComponent.renderInput()
             );
         } else {
             App = String.prototype.concat(
                 TitleComponent.renderTitle(),
+                FilterComponent.renderFilter(),
                 InputToDoItemComponent.renderInput(),
-                TodoListComponent.renderToDoItems(TODOS)
+                TodoListComponent.renderToDoItems(state.todos)
             );
         }
 

--- a/src/app/components/App.test.js
+++ b/src/app/components/App.test.js
@@ -32,11 +32,11 @@ describe('Component: AppComponent', () => {
 
     test('should get methods of class', () => {
         expect(AppViewComponent.renderApp).toBeDefined();
-        expect(AppViewComponent.renderAddToDoItemAt).toBeDefined();
+        expect(AppComponent.renderAddToDoItemAt).toBeDefined();
         expect(AppViewComponent.render).toBeDefined();
     });
 
-    describe('constructor component () =>', () => {
+    describe('constructor () =>', () => {
         test('should instance super class', () => {
             expect(AppViewComponent instanceof Component).toBe(true);
         });
@@ -50,20 +50,32 @@ describe('Component: AppComponent', () => {
             AppViewComponent.renderApp(element, state);
             expect(AppViewComponent.render).toHaveBeenCalledWith(
                 element,
-                AppViewComponent.renderAddToDoItemAt(mockIsEnabled('renderBottom'), state)
+                AppComponent.renderAddToDoItemAt(mockIsEnabled('renderBottom'), state)
             );
         });
 
         test('should be rendered the todo list data to the app across with hash passed', () => {
-            spyOn(AppViewComponent, 'renderAddToDoItemAt');
+            spyOn(AppComponent, 'renderAddToDoItemAt');
 
             AppViewComponent.renderApp(element, state);
-            expect(AppViewComponent.renderAddToDoItemAt).toHaveBeenCalledWith(mockIsEnabled('renderBottom'), state);
+            expect(AppComponent.renderAddToDoItemAt).toHaveBeenCalledWith(mockIsEnabled('renderBottom'), state);
             expect(mockIsEnabled).toHaveBeenCalledWith('renderBottom');
         });
     });
 
-    describe('- renderAddToDoItemAt () =>', () => {
+    describe('static joinComponents () =>', () => {
+        test('should join app components to render', () => {
+            let AppComponents = AppComponent.joinComponents([
+                'Component 1',
+                'Component 2'
+            ]);
+
+            expect(AppComponents)
+                .toBe('Component 1\nComponent 2');
+        });
+    });
+
+    describe('renderAddToDoItemAt () =>', () => {
         test('should get data from app components', () => {
             const components = [
                 { component: TitleComponent, method: 'renderTitle' },
@@ -74,37 +86,40 @@ describe('Component: AppComponent', () => {
 
             for (let component of components) {
                 spyOn(component.component, component.method);
-                AppViewComponent.renderAddToDoItemAt(false, state);
-                if (component.component === TodoListComponent) {
-                    expect(component.component[component.method]).toHaveBeenCalledWith(state.todos);
-                } else {
-                    expect(component.component[component.method]).toHaveBeenCalled();
-                }
+                AppComponent.renderAddToDoItemAt(false, state);
+                expect(component.component[component.method]).toHaveBeenCalled();
             }
+
+            expect(TodoListComponent.renderToDoItems).toHaveBeenCalledWith(state.todos);
+            expect(FilterComponent.renderFilter).toHaveBeenCalledWith(state.filters);
         });
 
         test('should be render input to add todo item at top when renderButton is disabled', () => {
-            let App = String.prototype.concat(
+            let Components = [
                 TitleComponent.renderTitle(),
-                FilterComponent.renderFilter(),
+                FilterComponent.renderFilter(state.filters),
                 InputToDoItemComponent.renderInput(),
                 TodoListComponent.renderToDoItems(state.todos)
-            );
+            ];
 
-            expect(AppViewComponent.renderAddToDoItemAt(false, state))
-                .toBe(`<div id="app">${App}</div>`);
+            spyOn(AppComponent, 'joinComponents');
+
+            AppComponent.renderAddToDoItemAt(false, state);
+            expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
         });
 
         test('should be render input to add todo item at bottom when renderButton is enabled', () => {
-            let App = String.prototype.concat(
+            let Components = [
                 TitleComponent.renderTitle(),
-                FilterComponent.renderFilter(),
+                FilterComponent.renderFilter(state.filters),
                 TodoListComponent.renderToDoItems(state.todos),
                 InputToDoItemComponent.renderInput()
-            );
+            ];
 
-            expect(AppViewComponent.renderAddToDoItemAt(true, state))
-                .toBe(`<div id="app">${App}</div>`)
+            spyOn(AppComponent, 'joinComponents');
+
+            AppComponent.renderAddToDoItemAt(true, state);
+            expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
         });
     });
 

--- a/src/app/components/App.test.js
+++ b/src/app/components/App.test.js
@@ -1,16 +1,19 @@
-import { state, window, AphroditeStyles } from './components.mock.js';
+import { state, window, document, AphroditeStyles } from './components.mock.js';
 
 import { isEnabled } from './../lib/feature';
 
 import AppComponent from './App';
 
 import Component from './View';
-import { TitleComponent } from './Title/Title';
-import { InputToDoItemComponent } from './Input/Input';
-import { TodoListComponent } from './Todo/TodoList';
+import TitleComponent from './Title/Title';
+import InputToDoItemComponent from './Input/Input';
+import TodoListComponent from './Todo/TodoList';
+import FilterComponent from './Filter/Filter';
 
 //noinspection JSAnnotator
 global.window = window;
+//noinspection JSAnnotator
+global.document = document;
 
 describe('Component: AppComponent', () => {
     let element = Object.prototype;
@@ -33,20 +36,21 @@ describe('Component: AppComponent', () => {
         expect(AppViewComponent.render).toBeDefined();
     });
 
-    describe('- constructor component () =>', () => {
+    describe('constructor component () =>', () => {
         test('should instance super class', () => {
             expect(AppViewComponent instanceof Component).toBe(true);
         });
     });
 
-    describe('- renderApp () =>', () => {
+    describe('renderApp () =>', () => {
+        const mockIsEnabled = jest.fn(isEnabled);
         test('should be render app to element', () => {
             spyOn(AppViewComponent, 'render');
 
             AppViewComponent.renderApp(element, state);
             expect(AppViewComponent.render).toHaveBeenCalledWith(
                 element,
-                AppViewComponent.renderAddToDoItemAt(isEnabled('renderBottom'), state.todos)
+                AppViewComponent.renderAddToDoItemAt(mockIsEnabled('renderBottom'), state)
             );
         });
 
@@ -54,7 +58,8 @@ describe('Component: AppComponent', () => {
             spyOn(AppViewComponent, 'renderAddToDoItemAt');
 
             AppViewComponent.renderApp(element, state);
-            expect(AppViewComponent.renderAddToDoItemAt).toHaveBeenCalledWith(isEnabled('renderBottom'), state.todos)
+            expect(AppViewComponent.renderAddToDoItemAt).toHaveBeenCalledWith(mockIsEnabled('renderBottom'), state);
+            expect(mockIsEnabled).toHaveBeenCalledWith('renderBottom');
         });
     });
 
@@ -63,12 +68,13 @@ describe('Component: AppComponent', () => {
             const components = [
                 { component: TitleComponent, method: 'renderTitle' },
                 { component: InputToDoItemComponent, method: 'renderInput' },
-                { component: TodoListComponent, method: 'renderToDoItems' }
+                { component: TodoListComponent, method: 'renderToDoItems' },
+                { component: FilterComponent, method: 'renderFilter' }
             ];
 
             for (let component of components) {
                 spyOn(component.component, component.method);
-                AppViewComponent.renderAddToDoItemAt(false, state.todos);
+                AppViewComponent.renderAddToDoItemAt(false, state);
                 if (component.component === TodoListComponent) {
                     expect(component.component[component.method]).toHaveBeenCalledWith(state.todos);
                 } else {
@@ -80,22 +86,24 @@ describe('Component: AppComponent', () => {
         test('should be render input to add todo item at top when renderButton is disabled', () => {
             let App = String.prototype.concat(
                 TitleComponent.renderTitle(),
+                FilterComponent.renderFilter(),
                 InputToDoItemComponent.renderInput(),
                 TodoListComponent.renderToDoItems(state.todos)
             );
 
-            expect(AppViewComponent.renderAddToDoItemAt(false, state.todos))
+            expect(AppViewComponent.renderAddToDoItemAt(false, state))
                 .toBe(`<div id="app">${App}</div>`);
         });
 
         test('should be render input to add todo item at bottom when renderButton is enabled', () => {
             let App = String.prototype.concat(
                 TitleComponent.renderTitle(),
+                FilterComponent.renderFilter(),
                 TodoListComponent.renderToDoItems(state.todos),
                 InputToDoItemComponent.renderInput()
             );
 
-            expect(AppViewComponent.renderAddToDoItemAt(true, state.todos))
+            expect(AppViewComponent.renderAddToDoItemAt(true, state))
                 .toBe(`<div id="app">${App}</div>`)
         });
     });

--- a/src/app/components/Filter/Filter.actions.js
+++ b/src/app/components/Filter/Filter.actions.js
@@ -4,3 +4,10 @@ export const filterTodoList = (status) => {
         status
     }
 };
+
+export const toggleFilter = (id) => {
+    return {
+        type: 'TOGGLE_FILTER',
+        id
+    }
+};

--- a/src/app/components/Filter/Filter.actions.js
+++ b/src/app/components/Filter/Filter.actions.js
@@ -1,0 +1,6 @@
+export const filterTodoList = (status) => {
+    return {
+        type: 'FILTER_TODO',
+        status
+    }
+};

--- a/src/app/components/Filter/Filter.actions.test.js
+++ b/src/app/components/Filter/Filter.actions.test.js
@@ -1,0 +1,21 @@
+import { filterTodoList } from './Filter.actions';
+
+describe('Actions: FilterComponent', () => {
+    test('should be imported', () => {
+        expect(filterTodoList).toBeDefined();
+    });
+
+    describe('filterTodoList', () => {
+        test('should return filters for filter todo list', () => {
+            expect(filterTodoList(true)).toEqual({
+                type: 'FILTER_TODO',
+                status: true
+            });
+
+            expect(filterTodoList(false)).toEqual({
+                type: 'FILTER_TODO',
+                status: false
+            });
+        });
+    });
+});

--- a/src/app/components/Filter/Filter.actions.test.js
+++ b/src/app/components/Filter/Filter.actions.test.js
@@ -1,8 +1,9 @@
-import { filterTodoList } from './Filter.actions';
+import { filterTodoList, toggleFilter } from './Filter.actions';
 
 describe('Actions: FilterComponent', () => {
     test('should be imported', () => {
         expect(filterTodoList).toBeDefined();
+        expect(toggleFilter).toBeDefined();
     });
 
     describe('filterTodoList', () => {
@@ -15,6 +16,15 @@ describe('Actions: FilterComponent', () => {
             expect(filterTodoList(false)).toEqual({
                 type: 'FILTER_TODO',
                 status: false
+            });
+        });
+    });
+
+    describe('toggleFilter', () => {
+        test('should change selected filter', () => {
+            expect(toggleFilter(1)).toEqual({
+                type: 'TOGGLE_FILTER',
+                id: 1
             });
         });
     });

--- a/src/app/components/Filter/Filter.js
+++ b/src/app/components/Filter/Filter.js
@@ -2,12 +2,13 @@ import { css } from 'aphrodite';
 import StylesFilterComponent from './Filter.styles';
 
 import { todos } from './../../state';
-import { filterTodoList } from './Filter.actions';
+import { filterTodoList, toggleFilter } from './Filter.actions';
 
 export class FilterComponent {
     static filterTodoList (event) {
         event.preventDefault();
         todos.dispatch(filterTodoList(FilterComponent.todoShouldFilter(event.target.value)));
+        todos.dispatch(toggleFilter(parseInt(event.target.getAttribute('data-id'))));
     }
 
     static todoShouldFilter (value) {
@@ -15,21 +16,26 @@ export class FilterComponent {
         return null;
     }
 
-    renderFilter () {
+    getFilters (FILTERS) {
+        return FILTERS.map((filter) => {
+            return `<label class="${css(StylesFilterComponent.filterOptions)}" for="filter-${filter.id}">
+                <i class="${css(StylesFilterComponent.filterOptionText)}">${filter.name}</i>
+                <input 
+                    type="radio" 
+                    name="filter" 
+                    id="filter-${filter.id}" 
+                    data-id="${filter.id}" 
+                    value="${filter.value}"
+                    ${filter.selected ? 'checked' : ''}
+                    >
+            </label>`
+        }).join('');
+    }
+
+    renderFilter (FILTERS) {
         return `<div id="filter" class="${css(StylesFilterComponent.filter)}">
             <h1 class="${css(StylesFilterComponent.filterTitle)}">Filter your tasks:</h1>
-            <label class="${css(StylesFilterComponent.filterOptions)}" for="filter-all">
-                <i class="${css(StylesFilterComponent.filterOptionText)}">all</i>
-                <input type="radio" name="filter" id="filter-all" value="${null}">
-            </label>
-            <label class="${css(StylesFilterComponent.filterOptions)}" for="filter-doing">
-                <i class="${css(StylesFilterComponent.filterOptionText)}">doing</i>
-                <input type="radio" name="filter" id="filter-doing" value="${false}">
-            </label>
-            <label class="${css(StylesFilterComponent.filterOptions)}" for="filter-done">
-                <i class="${css(StylesFilterComponent.filterOptionText)}">done</i>
-                <input type="radio" name="filter" id="filter-done" value="${true}">
-            </label>
+            ${this.getFilters(FILTERS)}
         </div>`;
     }
 }

--- a/src/app/components/Filter/Filter.js
+++ b/src/app/components/Filter/Filter.js
@@ -1,0 +1,37 @@
+import { css } from 'aphrodite';
+import StylesFilterComponent from './Filter.styles';
+
+import { todos } from './../../state';
+import { filterTodoList } from './Filter.actions';
+
+export class FilterComponent {
+    static filterTodoList (event) {
+        event.preventDefault();
+        todos.dispatch(filterTodoList(FilterComponent.todoShouldFilter(event.target.value)));
+    }
+
+    static todoShouldFilter (value) {
+        if (value !== 'null') return value === 'true';
+        return null;
+    }
+
+    renderFilter () {
+        return `<div id="filter" class="${css(StylesFilterComponent.filter)}">
+            <h1 class="${css(StylesFilterComponent.filterTitle)}">Filter your tasks:</h1>
+            <label class="${css(StylesFilterComponent.filterOptions)}" for="filter-all">
+                <i class="${css(StylesFilterComponent.filterOptionText)}">all</i>
+                <input type="radio" name="filter" id="filter-all" value="${null}">
+            </label>
+            <label class="${css(StylesFilterComponent.filterOptions)}" for="filter-doing">
+                <i class="${css(StylesFilterComponent.filterOptionText)}">doing</i>
+                <input type="radio" name="filter" id="filter-doing" value="${false}">
+            </label>
+            <label class="${css(StylesFilterComponent.filterOptions)}" for="filter-done">
+                <i class="${css(StylesFilterComponent.filterOptionText)}">done</i>
+                <input type="radio" name="filter" id="filter-done" value="${true}">
+            </label>
+        </div>`;
+    }
+}
+
+export default new FilterComponent

--- a/src/app/components/Filter/Filter.js
+++ b/src/app/components/Filter/Filter.js
@@ -8,7 +8,7 @@ export class FilterComponent {
     static filterTodoList (event) {
         event.preventDefault();
         todos.dispatch(filterTodoList(FilterComponent.todoShouldFilter(event.target.value)));
-        todos.dispatch(toggleFilter(parseInt(event.target.getAttribute('data-id'))));
+        todos.dispatch(toggleFilter(parseInt(event.target.getAttribute('data-id'), 10)));
     }
 
     static todoShouldFilter (value) {

--- a/src/app/components/Filter/Filter.styles.js
+++ b/src/app/components/Filter/Filter.styles.js
@@ -1,0 +1,26 @@
+import { GetStylesComponent, FontRobotoMedium } from './../../styles';
+
+export const StylesFilterComponent = {
+    filter: {
+        minHeight: '70px',
+        padding: '10px 0',
+        display: 'flex'
+    },
+    filterTitle: {
+        fontSize: '1.5rem',
+        color: 'cornflowerblue',
+        margin: '0'
+    },
+    filterOptions: {
+        margin: '7px 0',
+        flexGrow: '1',
+        fontFamily: FontRobotoMedium,
+        fontSize: '1.25rem',
+        cursor: 'pointer'
+    },
+    filterOptionText: {
+        padding: '0 5px 0 0'
+    }
+};
+
+export default GetStylesComponent(StylesFilterComponent);

--- a/src/app/components/Filter/Filter.test.js
+++ b/src/app/components/Filter/Filter.test.js
@@ -1,8 +1,8 @@
-import { AphroditeStyles, event } from './../components.mock';
+import { AphroditeStyles, event, state } from './../components.mock';
 import { css } from 'aphrodite';
 
 import { todos } from './../../state';
-import { filterTodoList } from './Filter.actions';
+import { filterTodoList, toggleFilter } from './Filter.actions';
 
 import filterComponent, { FilterComponent } from './Filter';
 
@@ -18,14 +18,17 @@ describe('Component: FilterComponent', () => {
     test('should get methods of class', () => {
         expect(filterComponent.renderFilter).toBeDefined();
         expect(typeof filterComponent.renderFilter).toBe('function');
+        expect(filterComponent.getFilters).toBeDefined();
+        expect(typeof filterComponent.getFilters).toBe('function');
         expect(FilterComponent.filterTodoList).toBeDefined();
         expect(typeof FilterComponent.filterTodoList).toBe('function');
         expect(FilterComponent.todoShouldFilter).toBeDefined();
         expect(typeof FilterComponent.todoShouldFilter).toBe('function');
     });
 
-    describe('filterTodoList () =>', () => {
+    describe('static filterTodoList () =>', () => {
         const mockFilterTodoList = jest.fn(filterTodoList);
+        const mockToggleFilterSelected = jest.fn(toggleFilter);
         beforeEach(() => {
             spyOn(todos, 'dispatch');
         });
@@ -53,6 +56,12 @@ describe('Component: FilterComponent', () => {
             expect(todos.dispatch).toHaveBeenCalledWith(mockFilterTodoList(null));
             expect(mockFilterTodoList).toHaveBeenCalledWith(null);
         });
+
+        test('should update state filter selected', () => {
+            FilterComponent.filterTodoList(event);
+            expect(todos.dispatch).toHaveBeenCalledWith(mockToggleFilterSelected(2));
+            expect(mockToggleFilterSelected).toHaveBeenCalledWith(2);
+        });
     });
 
     describe('static todoShouldFilter () =>', () => {
@@ -66,10 +75,24 @@ describe('Component: FilterComponent', () => {
         });
     });
 
-    describe('static renderFilter () =>', () => {
+    describe('getFilters () =>', () => {
+        test('should get filters', () => {
+            expect(filterComponent.getFilters(state.filters)).toBeDefined();
+            expect(typeof filterComponent.getFilters(state.filters)).toBe('string');
+        });
+    });
+
+    describe('renderFilter () =>', () => {
         test('should be render filter to app', () => {
-            expect(filterComponent.renderFilter()).toBeDefined();
-            expect(typeof filterComponent.renderFilter()).toBe('string');
+            expect(filterComponent.renderFilter(state.filters)).toBeDefined();
+            expect(typeof filterComponent.renderFilter(state.filters)).toBe('string');
+        });
+
+        test('should render got filters for todo list', () => {
+            spyOn(filterComponent, 'getFilters');
+
+            filterComponent.renderFilter(state.filters);
+            expect(filterComponent.getFilters).toHaveBeenCalledWith(state.filters);
         });
     });
 

--- a/src/app/components/Filter/Filter.test.js
+++ b/src/app/components/Filter/Filter.test.js
@@ -1,0 +1,79 @@
+import { AphroditeStyles, event } from './../components.mock';
+import { css } from 'aphrodite';
+
+import { todos } from './../../state';
+import { filterTodoList } from './Filter.actions';
+
+import filterComponent, { FilterComponent } from './Filter';
+
+describe('Component: FilterComponent', () => {
+    beforeEach(() => {
+        AphroditeStyles.before();
+    });
+
+    test('should be imported', () => {
+        expect(FilterComponent).toBeDefined();
+    });
+
+    test('should get methods of class', () => {
+        expect(filterComponent.renderFilter).toBeDefined();
+        expect(typeof filterComponent.renderFilter).toBe('function');
+        expect(FilterComponent.filterTodoList).toBeDefined();
+        expect(typeof FilterComponent.filterTodoList).toBe('function');
+        expect(FilterComponent.todoShouldFilter).toBeDefined();
+        expect(typeof FilterComponent.todoShouldFilter).toBe('function');
+    });
+
+    describe('filterTodoList () =>', () => {
+        const mockFilterTodoList = jest.fn(filterTodoList);
+        beforeEach(() => {
+            spyOn(todos, 'dispatch');
+        });
+
+        test('should filter for todo items than its done', () => {
+            event.target.value = 'true';
+
+            FilterComponent.filterTodoList(event);
+            expect(todos.dispatch).toHaveBeenCalledWith(mockFilterTodoList(true));
+            expect(mockFilterTodoList).toHaveBeenCalledWith(true);
+        });
+
+        test('should filter for todo items than its not done', () => {
+            event.target.value = 'false';
+
+            FilterComponent.filterTodoList(event);
+            expect(todos.dispatch).toHaveBeenCalledWith(mockFilterTodoList(false));
+            expect(mockFilterTodoList).toHaveBeenCalledWith(false);
+        });
+
+        test('should filter all todo items', () => {
+            event.target.value = 'null';
+
+            FilterComponent.filterTodoList(event);
+            expect(todos.dispatch).toHaveBeenCalledWith(mockFilterTodoList(null));
+            expect(mockFilterTodoList).toHaveBeenCalledWith(null);
+        });
+    });
+
+    describe('static todoShouldFilter () =>', () => {
+        test('should return all items when filter its null', () => {
+            expect(FilterComponent.todoShouldFilter('null')).toBe(null);
+        });
+
+        test('should return what items would filter', () => {
+            expect(FilterComponent.todoShouldFilter('true')).toBe(true);
+            expect(FilterComponent.todoShouldFilter('false')).toBe(false);
+        });
+    });
+
+    describe('static renderFilter () =>', () => {
+        test('should be render filter to app', () => {
+            expect(filterComponent.renderFilter()).toBeDefined();
+            expect(typeof filterComponent.renderFilter()).toBe('string');
+        });
+    });
+
+    afterEach(() => {
+        AphroditeStyles.after();
+    });
+});

--- a/src/app/components/Input/Input.js
+++ b/src/app/components/Input/Input.js
@@ -2,7 +2,7 @@ import { todos } from './../../state';
 
 import { addTodo } from './../../actions';
 
-import { css } from 'aphrodite'
+import { css } from 'aphrodite';
 import styles from './../../styles';
 
 export class InputToDoItemComponent {
@@ -21,7 +21,7 @@ export class InputToDoItemComponent {
         }
     }
 
-    static renderInput () {
+    renderInput () {
         return `<div class="todo__input ${css(styles.divFullWidth, styles.divAlignFlex, styles.divAddTodo)}">
             <button class="${css(styles.buttonAddTodo)}" id="addTodo">
                 <i class="add circle icon ${css(styles.iconAddTodoButton)}"></i>
@@ -37,3 +37,5 @@ export class InputToDoItemComponent {
         </div>`;
     }
 }
+
+export default new InputToDoItemComponent

--- a/src/app/components/Input/Input.test.js
+++ b/src/app/components/Input/Input.test.js
@@ -1,33 +1,17 @@
-import { AphroditeStyles } from './../components.mock';
+import { AphroditeStyles, event, document } from './../components.mock';
 
 import { todos } from './../../state';
 import { addTodo } from './../../actions';
 
-import { InputToDoItemComponent } from './Input';
+import InputTodoItemComponent, { InputToDoItemComponent } from './Input';
 
-const event = {
-    target: {
-        matches: selector => true,
-        getAttribute: attribute => '1'
-    },
-    stopPropagation: () => {},
-    preventDefault: () => {},
-    which: 13,
-    key: 'Enter'
-};
-
-global.document = {
-    getElementById: id => {
-        return {
-            value: `data ${id}`,
-            focus: () => {}
-        }
-    }
-};
+//noinspection JSAnnotator
+global.document = document;
 
 describe('Component: InputToDoItemComponent', () => {
     test('should be imported', () => {
         expect(InputToDoItemComponent).toBeDefined();
+        expect(InputTodoItemComponent).toBeDefined();
     });
 
     test('should get methods of class', () => {
@@ -35,8 +19,8 @@ describe('Component: InputToDoItemComponent', () => {
         expect(typeof InputToDoItemComponent.addTodoItem).toBe('function');
         expect(InputToDoItemComponent.addTodoItemWithEnter).toBeDefined();
         expect(typeof InputToDoItemComponent.addTodoItemWithEnter).toBe('function');
-        expect(InputToDoItemComponent.renderInput).toBeDefined();
-        expect(typeof InputToDoItemComponent.renderInput).toBe('function');
+        expect(InputTodoItemComponent.renderInput).toBeDefined();
+        expect(typeof InputTodoItemComponent.renderInput).toBe('function');
     });
 
     describe('static addTodoItemWithEnter', () => {
@@ -82,8 +66,8 @@ describe('Component: InputToDoItemComponent', () => {
         });
 
         test('should return title app', () => {
-            expect(InputToDoItemComponent.renderInput()).toBeDefined();
-            expect(typeof InputToDoItemComponent.renderInput()).toBe('string');
+            expect(InputTodoItemComponent.renderInput()).toBeDefined();
+            expect(typeof InputTodoItemComponent.renderInput()).toBe('string');
         });
 
         afterEach(() => {

--- a/src/app/components/Title/Title.js
+++ b/src/app/components/Title/Title.js
@@ -2,7 +2,7 @@ import { css } from 'aphrodite'
 import styles from './../../styles';
 
 export class TitleComponent {
-    static renderTitle () {
+    renderTitle () {
         return `<div class="${css(styles.divTitle)}">
             <img src="public/images/logo.png" class="${css(styles.imageRounded, styles.imageTitle)}" alt="">
             <h1 class="${css(styles.fontTitle, styles.noMargin)}">ToDoList</h1>
@@ -10,3 +10,5 @@ export class TitleComponent {
         </div>`;
     }
 }
+
+export default new TitleComponent

--- a/src/app/components/Title/Title.test.js
+++ b/src/app/components/Title/Title.test.js
@@ -1,6 +1,6 @@
 import { AphroditeStyles } from './../components.mock';
 
-import { TitleComponent } from './Title';
+import TitleComponent from './Title';
 
 describe('Component: TitleComponent', () => {
     test('should be imported', () => {

--- a/src/app/components/Todo/TodoItem.js
+++ b/src/app/components/Todo/TodoItem.js
@@ -11,7 +11,7 @@ export class TodoItemComponent {
         todos.dispatch(toggleTodoState(id));
     }
 
-    static renderToDoItem (todo) {
+    renderToDoItem (todo) {
         const todoClass = `todo__item todo__item--${todo.done ? 'done' : 'open'}`;
         return `<li>
             <div class="ui checkbox">
@@ -38,3 +38,5 @@ export class TodoItemComponent {
         </li>`;
     }
 }
+
+export default new TodoItemComponent

--- a/src/app/components/Todo/TodoItem.test.js
+++ b/src/app/components/Todo/TodoItem.test.js
@@ -3,7 +3,7 @@ import { state, AphroditeStyles } from './../components.mock';
 import { todos } from './../../state';
 import { toggleTodoState } from './../../actions';
 
-import { TodoItemComponent } from './TodoItem';
+import ToDoItemComponent, { TodoItemComponent } from './TodoItem';
 
 const event = {
     target: {
@@ -19,8 +19,8 @@ describe('Component: TodoItemComponent', () => {
     });
 
     test('should get methods of class', () => {
-        expect(TodoItemComponent.renderToDoItem).toBeDefined();
-        expect(typeof TodoItemComponent.renderToDoItem).toBe('function');
+        expect(ToDoItemComponent.renderToDoItem).toBeDefined();
+        expect(typeof ToDoItemComponent.renderToDoItem).toBe('function');
         expect(TodoItemComponent.toggleStatusTodoItem).toBeDefined();
         expect(typeof TodoItemComponent.toggleStatusTodoItem).toBe('function');
     });
@@ -42,8 +42,8 @@ describe('Component: TodoItemComponent', () => {
         });
 
         test('should return element', () => {
-            expect(TodoItemComponent.renderToDoItem(state.todos[0])).toBeDefined();
-            expect(typeof TodoItemComponent.renderToDoItem(state.todos[0])).toBe('string');
+            expect(ToDoItemComponent.renderToDoItem(state.todos[0])).toBeDefined();
+            expect(typeof ToDoItemComponent.renderToDoItem(state.todos[0])).toBe('string');
         });
 
         afterEach(() => {

--- a/src/app/components/Todo/TodoItem.test.js
+++ b/src/app/components/Todo/TodoItem.test.js
@@ -1,17 +1,9 @@
-import { state, AphroditeStyles } from './../components.mock';
+import { state, AphroditeStyles, event } from './../components.mock';
 
 import { todos } from './../../state';
 import { toggleTodoState } from './../../actions';
 
 import ToDoItemComponent, { TodoItemComponent } from './TodoItem';
-
-const event = {
-    target: {
-        matches: selector => true,
-        getAttribute: attribute => '1'
-    },
-    stopPropagation: () => true
-};
 
 describe('Component: TodoItemComponent', () => {
     test('should be imported', () => {
@@ -31,8 +23,8 @@ describe('Component: TodoItemComponent', () => {
             spyOn(todos, 'dispatch');
 
             TodoItemComponent.toggleStatusTodoItem(event);
-            expect(todos.dispatch).toHaveBeenCalledWith(mockToggleTodoItem(1));
-            expect(mockToggleTodoItem).toHaveBeenCalledWith(1);
+            expect(todos.dispatch).toHaveBeenCalledWith(mockToggleTodoItem(2));
+            expect(mockToggleTodoItem).toHaveBeenCalledWith(2);
         });
     });
 

--- a/src/app/components/Todo/TodoList.js
+++ b/src/app/components/Todo/TodoList.js
@@ -1,14 +1,24 @@
+import { todos } from './../../state';
+
 import { css } from 'aphrodite'
 import styles from './../../styles';
 
-import { TodoItemComponent } from './TodoItem';
+import TodoItemComponent from './TodoItem';
 
 export class TodoListComponent {
-    static renderToDoItems (TODOS) {
-        return `<ul class="todo ${css(styles.divFullWidth, styles.todoListJustify)}">${this.getToDoItems(TODOS)}</ul>`;
+    constructor () {
+        this.getToDos = TODOS => TodoListComponent.getToDoItems(TODOS);
     }
 
     static getToDoItems (TODOS) {
         return TODOS.map(TodoItemComponent.renderToDoItem).join('');
     }
+
+    renderToDoItems (TODOS) {
+        return `<ul class="todo ${css(styles.divFullWidth, styles.todoListJustify)}">
+            ${this.getToDos(TODOS)}
+        </ul>`;
+    }
 }
+
+export default new TodoListComponent

--- a/src/app/components/Todo/TodoList.test.js
+++ b/src/app/components/Todo/TodoList.test.js
@@ -1,7 +1,7 @@
 import { AphroditeStyles, state } from './../components.mock';
 
-import { TodoListComponent } from './TodoList';
-import { TodoItemComponent } from './TodoItem';
+import ToDoListComponent, { TodoListComponent } from './TodoList';
+import TodoItemComponent from './TodoItem';
 
 describe('Component: TodoListComponent', () => {
     const testComponentStaticMethod = (rendered) => {
@@ -11,11 +11,12 @@ describe('Component: TodoListComponent', () => {
 
     test('should be imported', () => {
         expect(TodoListComponent).toBeDefined();
+        expect(ToDoListComponent).toBeDefined();
     });
 
     test('should get methods of class', () => {
-        expect(TodoListComponent.renderToDoItems).toBeDefined();
-        expect(typeof TodoListComponent.renderToDoItems).toBe('function');
+        expect(ToDoListComponent.renderToDoItems).toBeDefined();
+        expect(typeof ToDoListComponent.renderToDoItems).toBe('function');
         expect(TodoListComponent.getToDoItems).toBeDefined();
         expect(typeof TodoListComponent.getToDoItems).toBe('function');
     });
@@ -24,20 +25,24 @@ describe('Component: TodoListComponent', () => {
         AphroditeStyles.before();
     });
 
-    describe('- static renderToDoItems () =>', () => {
-        test('should return all items listing on ToDo list', () => {
-            testComponentStaticMethod(TodoListComponent.renderToDoItems(state.todos));
-        });
+    describe('constructor () =>', () => {
+        test('should create getter for todos list', () => {
+            expect(ToDoListComponent.getToDos).toBeDefined();
+            expect(typeof ToDoListComponent.getToDos).toBe('function');
+        }); 
+    });
 
-        test('should get ToDo list from initial state list', () => {
+    describe('getToDos () =>', () => {
+        test('should get the todo list items', () => {
             spyOn(TodoListComponent, 'getToDoItems');
 
-            TodoListComponent.renderToDoItems();
-            expect(TodoListComponent.getToDoItems).toHaveBeenCalled();
+            let todos = ToDoListComponent.getToDos(state.todos);
+            expect(TodoListComponent.getToDoItems).toHaveBeenCalledWith(state.todos);
+            expect(todos).toEqual(TodoListComponent.getToDoItems(state.todos));
         });
     });
 
-    describe('- static getToDos () =>', () => {
+    describe('static getToDos () =>', () => {
         test('should render all ToDo items to the list ToDos', () => {
             spyOn(TodoItemComponent, 'renderToDoItem');
 
@@ -47,6 +52,19 @@ describe('Component: TodoListComponent', () => {
 
         test('should return elements like string to the ToDo list', () => {
             testComponentStaticMethod(TodoListComponent.getToDoItems(state.todos));
+        });
+    });
+
+    describe('renderToDoItems () =>', () => {
+        test('should return all items listing on ToDo list', () => {
+            testComponentStaticMethod(ToDoListComponent.renderToDoItems(state.todos));
+        });
+
+        test('should get todo list app from initial state list', () => {
+            spyOn(ToDoListComponent, 'getToDos');
+
+            ToDoListComponent.renderToDoItems(state.todos);
+            expect(ToDoListComponent.getToDos).toHaveBeenCalledWith(state.todos);
         });
     });
 

--- a/src/app/components/components.mock.js
+++ b/src/app/components/components.mock.js
@@ -6,13 +6,18 @@ export const state = {
         { id: 1, text: 'Add ability to filter todos', done: false },
         { id: 2, text: 'Filter todos by status', done: false },
         { id: 3, text: 'Filter todos by text', done: false }
+    ],
+    filters: [
+        { id: 1, name: 'Mostrar ToDos', selected: true, value: null },
+        { id: 2, name: 'Somente abertos', selected: false, value: false},
+        { id: 3, name: 'Somente fechados', selected: true }
     ]
 };
 
 export const event = {
     target: {
         matches: selector => true,
-        getAttribute: attribute => '1'
+        getAttribute: attribute => '2'
     },
     stopPropagation: () => {},
     preventDefault: () => {},

--- a/src/app/components/components.mock.js
+++ b/src/app/components/components.mock.js
@@ -9,9 +9,32 @@ export const state = {
     ]
 };
 
+export const event = {
+    target: {
+        matches: selector => true,
+        getAttribute: attribute => '1'
+    },
+    stopPropagation: () => {},
+    preventDefault: () => {},
+    which: 13,
+    key: 'Enter'
+};
+
 export const window = {
     location: {
         hash: '#renderBottom'
+    }
+};
+
+export const document = {
+    body: {
+        addEventListener: (eventName, listener) => listener(event)
+    },
+    getElementById: id => {
+        return {
+            value: `data ${id}`,
+            focus: () => {}
+        }
     }
 };
 

--- a/src/app/events.js
+++ b/src/app/events.js
@@ -2,9 +2,11 @@ import {listen} from './lib/events';
 
 import { InputToDoItemComponent } from './components/Input/Input';
 import { TodoItemComponent } from './components/Todo/TodoItem';
+import { FilterComponent } from './components/Filter/Filter';
 
 export const registerEventHandlers = () => {
     listen('click', '#addTodo', InputToDoItemComponent.addTodoItem);
     listen('keydown', '#todoInput', InputToDoItemComponent.addTodoItemWithEnter);
     listen('click', '.js_toggle_todo', TodoItemComponent.toggleStatusTodoItem);
+    listen('change', '#filter label input[type="radio"]', FilterComponent.filterTodoList);
 };

--- a/src/app/events.test.js
+++ b/src/app/events.test.js
@@ -1,29 +1,14 @@
+import { event, document } from './components/components.mock';
 import { listen } from './lib/events';
 
 import { registerEventHandlers } from './events';
 
 import { InputToDoItemComponent } from './components/Input/Input';
 import { TodoItemComponent } from './components/Todo/TodoItem';
+import { FilterComponent } from './components/Filter/Filter';
 
-const event = {
-    target: {
-        matches: selector => true,
-        getAttribute: attribute => '1'
-    },
-    stopPropagation: () => true
-};
-
-global.document = {
-    body: {
-        addEventListener: (eventName, listener) => listener(event)
-    },
-    getElementById: id => {
-        return {
-            value: `data input ${id}`,
-            focus: () => {}
-        }
-    }
-};
+//noinspection JSAnnotator
+global.document = document;
 
 describe('Events: registerEventHandlers', () => {
     test('should be imported register of events handlers', () => {
@@ -62,11 +47,13 @@ describe('Events: registerEventHandlers', () => {
             spyOn(InputToDoItemComponent, 'addTodoItem');
             spyOn(InputToDoItemComponent, 'addTodoItemWithEnter');
             spyOn(TodoItemComponent, 'toggleStatusTodoItem');
+            spyOn(FilterComponent, 'filterTodoList');
 
             registerEventHandlers();
             expect(InputToDoItemComponent.addTodoItem).toHaveBeenCalledWith(event);
             expect(InputToDoItemComponent.addTodoItemWithEnter).toHaveBeenCalledWith(event);
             expect(TodoItemComponent.toggleStatusTodoItem).toHaveBeenCalledWith(event);
+            expect(FilterComponent.filterTodoList).toHaveBeenCalledWith(event);
         });
     });
 });

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -79,12 +79,8 @@ export const todoChangeHandler = (state, change) => {
             break;
         case 'TOGGLE_FILTER':
             for (let filter of state.filters) {
-                if (filter.selected) {
-                    filter.selected = false;
-                }
-
-                if (filter.id === change.id) {
-                    filter.selected = true;
+                if (filter.selected || filter.id === change.id) {
+                    filter.selected = !filter.selected;
                 }
             }
     }

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -1,4 +1,4 @@
-import {createStore} from './lib/state';
+import { createStore } from './lib/state';
 
 const initialState = {
     todos: [
@@ -25,7 +25,9 @@ const initialState = {
     ]
 };
 
-function todoChangeHandler(state, change) {
+const TODOS = initialState.todos;
+
+export const todoChangeHandler = (state, change) => {
     switch(change.type) {
         case 'ADD_TODO':
             state.todos.push({
@@ -42,7 +44,22 @@ function todoChangeHandler(state, change) {
                 }
             }
             break;
+        case 'FILTER_TODO':
+            if (change.status == null) {
+                state.todos = TODOS;
+                break;
+            } else {
+                let todos = [];
+                for (let todo of TODOS) {
+                    if (todo.done === change.status) {
+                        todos.push(todo);
+                    }
+                }
+                state.todos = todos;
+                break;
+            }
+            break;
     }
-}
+};
 
 export const todos = createStore(todoChangeHandler, initialState);

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -16,11 +16,6 @@ const initialState = {
             id: 2,
             text: 'Filter todos by status',
             done: false
-        },
-        {
-            id: 3,
-            text: 'Filter todos by text',
-            done: false
         }
     ],
     filters: [
@@ -63,19 +58,15 @@ export const todoChangeHandler = (state, change) => {
             }
             break;
         case 'FILTER_TODO':
-            if (change.status === null) {
-                state.todos = TODOS;
-                break;
-            } else {
-                let todos = [];
+            let todos = change.status === null ? TODOS : [];
+            if (todos.length === 0) {
                 for (let todo of TODOS) {
                     if (todo.done === change.status) {
                         todos.push(todo);
                     }
                 }
-                state.todos = todos;
-                break;
             }
+            state.todos = todos;
             break;
         case 'TOGGLE_FILTER':
             for (let filter of state.filters) {

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -22,6 +22,24 @@ const initialState = {
             text: 'Filter todos by text',
             done: false
         }
+    ],
+    filters: [
+        {
+            id: 1,
+            name: 'Mostrar ToDos',
+            selected: true,
+            value: null
+        }, {
+            id: 2,
+            name: 'Somente abertos',
+            selected: false,
+            value: false
+        }, {
+            id: 3,
+            name: 'Somente fechados',
+            value: true,
+            selected: false
+        }
     ]
 };
 
@@ -45,7 +63,7 @@ export const todoChangeHandler = (state, change) => {
             }
             break;
         case 'FILTER_TODO':
-            if (change.status == null) {
+            if (change.status === null) {
                 state.todos = TODOS;
                 break;
             } else {
@@ -59,6 +77,16 @@ export const todoChangeHandler = (state, change) => {
                 break;
             }
             break;
+        case 'TOGGLE_FILTER':
+            for (let filter of state.filters) {
+                if (filter.selected) {
+                    filter.selected = false;
+                }
+
+                if (filter.id === change.id) {
+                    filter.selected = true;
+                }
+            }
     }
 };
 

--- a/src/app/state.test.js
+++ b/src/app/state.test.js
@@ -1,0 +1,74 @@
+import { createStore } from './lib/state';
+
+import { todos, todoChangeHandler } from './state';
+
+import { addTodo, toggleTodoState } from './actions';
+import { filterTodoList } from './components/Filter/Filter.actions';
+
+import { state } from './components/components.mock';
+
+describe('State: App', () => {
+    test('should be imported reducer', () => {
+        expect(todoChangeHandler).toBeDefined();
+        expect(typeof todoChangeHandler).toBe('function');
+    });
+
+    test('should be created store', () => {
+        expect(todos).toBeDefined();
+        expect(typeof todos).toBe('object');
+    });
+
+    const mockReducer = jest.fn(todoChangeHandler);
+    const mockCreateStore = jest.fn(createStore);
+
+    let store = mockCreateStore(mockReducer, state);
+
+    describe('createStore () =>', () => {
+        test('should be created the store for control app state', () => {
+            expect(store.dispatch).toBeDefined();
+            expect(store.subscribe).toBeDefined();
+            expect(store.getState).toBeDefined();
+        });
+
+        test('should use reducer for update store state', () => {
+            store.dispatch(filterTodoList(null));
+            expect(mockReducer).toHaveBeenCalledWith(state, filterTodoList(null));
+        });
+    });
+
+    describe('todoChangeHandler () =>', () => {
+        describe('change: ADD_TODO', () => {
+            test('should add new todo to state todo list', () => {
+                expect(state.todos.length).toBe(4);
+                mockReducer(state, addTodo('my task'));
+                expect(state.todos.length).toBe(5);
+                expect(state.todos[state.todos.length-1]).toEqual({
+                    id: state.todos.length-1,
+                    text: 'my task',
+                    done: false
+                });
+            });
+        });
+
+        describe('change: TODO_TOGGLE_DONE', () => {
+            test('should toggle done status todo item', () => {
+                expect(state.todos[0].done).toBe(true);
+                mockReducer(state, toggleTodoState(0));
+                expect(state.todos[0].done).toBe(false);
+                expect(state.todos[1].done).toBe(false);
+                mockReducer(state, toggleTodoState(1));
+                expect(state.todos[1].done).toBe(true);
+            });
+        });
+
+        describe('change: FILTER_TODO', () => {
+            test('should filter for all todo items', () => {
+                expect(state.todos.length).toBe(5);
+                mockReducer(state, filterTodoList(false));
+                expect(state.todos.length).toBe(4);
+                mockReducer(state, filterTodoList(true));
+                expect(state.todos.length).toBe(1);
+            });
+        });
+    });
+});

--- a/src/app/state.test.js
+++ b/src/app/state.test.js
@@ -3,7 +3,7 @@ import { createStore } from './lib/state';
 import { todos, todoChangeHandler } from './state';
 
 import { addTodo, toggleTodoState } from './actions';
-import { filterTodoList } from './components/Filter/Filter.actions';
+import { filterTodoList, toggleFilter } from './components/Filter/Filter.actions';
 
 import { state } from './components/components.mock';
 
@@ -68,6 +68,15 @@ describe('State: App', () => {
                 expect(state.todos.length).toBe(4);
                 mockReducer(state, filterTodoList(true));
                 expect(state.todos.length).toBe(1);
+            });
+        });
+
+        describe('change: TOGGLE_FILTER', () => {
+            test('should update filter selected', () => {
+                expect(state.filters[0].selected).toBe(true);
+                mockReducer(state, toggleFilter(2));
+                expect(state.filters[0].selected).toBe(false);
+                expect(state.filters[1].selected).toBe(true);
             });
         });
     });

--- a/src/app/state.test.js
+++ b/src/app/state.test.js
@@ -37,11 +37,23 @@ describe('State: App', () => {
     });
 
     describe('todoChangeHandler () =>', () => {
+        describe('change: FILTER_TODO', () => {
+            test('should filter for all todo items', () => {
+                expect(state.todos.length).toBe(3);
+                mockReducer(state, filterTodoList(false));
+                expect(state.todos.length).toBe(2);
+                mockReducer(state, filterTodoList(true));
+                expect(state.todos.length).toBe(1);
+                mockReducer(state, filterTodoList(null));
+                expect(state.todos.length).toBe(3);
+            });
+        });
+
         describe('change: ADD_TODO', () => {
             test('should add new todo to state todo list', () => {
-                expect(state.todos.length).toBe(4);
+                expect(state.todos.length).toBe(3);
                 mockReducer(state, addTodo('my task'));
-                expect(state.todos.length).toBe(5);
+                expect(state.todos.length).toBe(4);
                 expect(state.todos[state.todos.length-1]).toEqual({
                     id: state.todos.length-1,
                     text: 'my task',
@@ -58,16 +70,6 @@ describe('State: App', () => {
                 expect(state.todos[1].done).toBe(false);
                 mockReducer(state, toggleTodoState(1));
                 expect(state.todos[1].done).toBe(true);
-            });
-        });
-
-        describe('change: FILTER_TODO', () => {
-            test('should filter for all todo items', () => {
-                expect(state.todos.length).toBe(5);
-                mockReducer(state, filterTodoList(false));
-                expect(state.todos.length).toBe(4);
-                mockReducer(state, filterTodoList(true));
-                expect(state.todos.length).toBe(1);
             });
         });
 

--- a/src/app/styles.js
+++ b/src/app/styles.js
@@ -1,53 +1,41 @@
-import{ StyleSheet } from 'aphrodite/no-important';
+import{ StyleSheet, css } from 'aphrodite';
 
-const FontRoboto = {
+export const FontRoboto = {
     fontFamily: 'Roboto',
     fontWeight: 'normal',
     fontStyle: 'normal',
     src: "url('/public/fonts/Roboto/roboto-regular.woff') format('woff2'), url('/public/fonts/Roboto/roboto-regular.woff') format('woff')"
 };
 
-const FontRobotoMedium = {
+export const FontRobotoMedium = {
     fontFamily: 'Roboto Medium',
     fontWeight: 'normal',
     fontStyle: 'normal',
     src: "url('/public/fonts/Roboto/roboto-medium.woff') format('woff2'), url('/public/fonts/Roboto/roboto-medium.woff') format('woff')"
 };
 
-const FontRobotoBlack = {
+export const FontRobotoBlack = {
     fontFamily: 'Roboto Black',
     fontWeight: 'normal',
     fontStyle: 'normal',
     src: "url('/public/fonts/Roboto/roboto-black.woff') format('woff2'), url('/public/fonts/Roboto/roboto-black.woff') format('woff')"
 };
 
-const FontRobotoCondensed = {
+export const FontRobotoCondensed = {
     fontFamily: 'Roboto Condensed',
     fontWeight: 'normal',
     fontStyle: 'normal',
     src: "url('/public/fonts/RobotoCondensed/robotocondensed-regular.woff') format('woff2'), url('/public/fonts/RobotoCondensed/robotocondensed-regular.woff') format('woff')"
 };
 
-const FontRobotoCondensedBold = {
+export const FontRobotoCondensedBold = {
     fontFamily: 'Roboto Condensed Bold',
     fontWeight: 'normal',
     fontStyle: 'normal',
     src: "url('/public/fonts/RobotoCondensed/robotocondensed-bold.woff') format('woff2'), url('/public/fonts/RobotoCondensed/robotocondensed-bold.woff') format('woff')"
 };
 
-const FontArimo = {
-    fontFamily: 'Arimo',
-    fontWeight: 'normal',
-    fontStyle: 'normal',
-    src: "url('/public/fonts/Arimo/arimo-regular.woff') format('woff2'), url('/public/fonts/Arimo/arimo-regular.woff') format('woff')"
-};
-
-const FontArimoBold = {
-    fontFamily: 'Arimo Bold',
-    fontWeight: 'normal',
-    fontStyle: 'normal',
-    src: "url('/public/fonts/Arimo/arimo-bold.woff') format('woff2'), url('/public/fonts/Arimo/arimo-bold.woff') format('woff')"
-};
+export const GetStylesComponent = styles => StyleSheet.create(styles);
 
 export default StyleSheet.create({
     divTitle: {


### PR DESCRIPTION
## #6 Adicione um filtro de status como TESTE

Como um usuário, eu quero ter uma opção para esconder itens que não me interessam
baseado nos seus status.
Essa feature deve ser implementada como um teste, similar ao "renderBottom",
e deve se chamar "filter".
Por favor, implemente o filtro abaixo da lista como radio buttons, contendo estas três opções:

- Mostrar todos (habilitado por padrão)
- Somente abertos
- Somente fechados

Estes radio buttons devem ser mutuamente exclusivos, apenas um deles pode ser selecionado.

Ex.: se "Somente abertos" estiver selecionados, apenas os todo items que tiverem o `done`
setado como `false` devem ser mostrados.

![image](https://cloud.githubusercontent.com/assets/14860216/24083123/2de8d4ce-0cb0-11e7-9a39-6bf147a0fae0.png)
