### PR TITLE
WEB-104 - Adicione um TESTE para mudar a posição do filtro

### DIFF
--- a/.docs/tasks.md
+++ b/.docs/tasks.md
@@ -39,9 +39,9 @@ Estes radio buttons devem ser mutuamente exclusivos, apenas um deles pode ser se
 Ex.: se "Somente abertos" estiver selecionados, apenas os ToDo items que tiverem o `done`
 setado como `false` devem ser mostrados.
 
-### WEB-104
+### ~~WEB-104~~
 
-- [ ] Adicione um TESTE para mudar a posição do filtro
+- [x] Adicione um TESTE para mudar a posição do filtro
 
 Descobrimos que para usuários que tem o teste "renderBottom" habilitado, ficou difícil
 utilizar o filtro. Nossos especialistas UX entendem que quando os dois testes estão

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -31,38 +31,31 @@ export class AppComponent extends Component {
                 InputToDoItemComponent.renderInput(state.severities),
             );
         } else {
+            let indexInput;
             switch (isEnabled.value) {
                 case 'filter':
-                    let next = whereRender.next();
-                    if (next.done) {
-                        Components.splice(1, 0,
-                            FilterComponent.renderFilter(state.filters),
-                            InputToDoItemComponent.renderInput(state.severities)
-                        );
-                    } else {
-                        if (next.value === 'filterTop') {
-                            Components.splice(1, 0,
-                                FilterComponent.renderFilter(state.filters),
-                                InputToDoItemComponent.renderInput(state.severities)
-                            );
+                    let indexFilter;
+                    if (whereRender.next().value === 'renderBottom') {
+                        indexInput = Components.length;
+                        if (whereRender.next().value === 'filterTop') {
+                            indexFilter = 1;
+                        } else {
+                            indexFilter = 2;
                         }
 
-                        if (next.value === 'renderBottom') {
-                            Components.splice(2, 0, InputToDoItemComponent.renderInput(state.severities));
-                            if (whereRender.next().value === 'filterTop') {
-                                Components.splice(0, 0, FilterComponent.renderFilter(state.filters));
-                            } else {
-                                Components.splice(2, 0, FilterComponent.renderFilter(state.filters));
-                            }
-                        }
+                        Components.splice(indexFilter || 1, 0,
+                            FilterComponent.renderFilter(state.filters),
+                        );
                     }
                     break;
                 case 'renderBottom':
-                    Components.splice(2, 0,
-                        InputToDoItemComponent.renderInput(state.severities),
-                    );
+                    indexInput = Components.length;
                     break;
             }
+
+            Components.splice(indexInput || 1, 0,
+                InputToDoItemComponent.renderInput(state.severities)
+            );
         }
 
         return `<div id="app">${AppComponent.joinComponents(Components)}</div>`;

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -1,5 +1,4 @@
 import { isEnabled } from './../lib/feature';
-import { store } from '../state';
 
 import Component from  './View';
 
@@ -7,24 +6,17 @@ import TitleComponent from './Title/Title';
 import InputToDoItemComponent from './Input/Input';
 import TodoListComponent from './Todo/TodoList';
 import FilterComponent from './Filter/Filter';
+import { TestingFeaturesComponent } from './TestingFeatures/TestingFeatures';
 
-export default class AppComponent extends Component {
+export class AppComponent extends Component {
     constructor () {
         super();
     }
 
     renderApp (el, state) {
-        AppComponent.windowHashChange();
+        TestingFeaturesComponent.windowHashChange(el, state);
         let whereRender = isEnabled(['filter', 'renderBottom', 'filterTop']);
         this.render(el, AppComponent.renderAddToDoItemAt(whereRender, state));
-    }
-
-    static windowHashChange () {
-        window.addEventListener('hashchange', (event) => {
-            const App = new AppComponent;
-            App.renderApp(document.getElementById('root'), store.getState());
-            event.stopImmediatePropagation();
-        });
     }
 
     static joinComponents (Components) {
@@ -32,11 +24,10 @@ export default class AppComponent extends Component {
     }
 
     static renderAddToDoItemAt (whereRender, state) {
-        let isEnabled = whereRender.next();
         let Components = [TitleComponent.renderTitle(), TodoListComponent.renderToDoItems(state.todos)];
+        let isEnabled = whereRender.next();
         if (isEnabled.done) {
             Components.splice(1, 0,
-                FilterComponent.renderFilter(state.filters),
                 InputToDoItemComponent.renderInput(state.severities),
             );
         } else {
@@ -45,8 +36,8 @@ export default class AppComponent extends Component {
                     let next = whereRender.next();
                     if (next.done) {
                         Components.splice(1, 0,
-                            InputToDoItemComponent.renderInput(state.severities),
-                            FilterComponent.renderFilter(state.filters)
+                            FilterComponent.renderFilter(state.filters),
+                            InputToDoItemComponent.renderInput(state.severities)
                         );
                     } else {
                         if (next.value === 'filterTop') {
@@ -61,7 +52,7 @@ export default class AppComponent extends Component {
                             if (whereRender.next().value === 'filterTop') {
                                 Components.splice(0, 0, FilterComponent.renderFilter(state.filters));
                             } else {
-                                Components.splice(1, 0, FilterComponent.renderFilter(state.filters));
+                                Components.splice(2, 0, FilterComponent.renderFilter(state.filters));
                             }
                         }
                     }
@@ -69,7 +60,6 @@ export default class AppComponent extends Component {
                 case 'renderBottom':
                     Components.splice(2, 0,
                         InputToDoItemComponent.renderInput(state.severities),
-                        FilterComponent.renderFilter(state.filters)
                     );
                     break;
             }
@@ -78,3 +68,5 @@ export default class AppComponent extends Component {
         return `<div id="app">${AppComponent.joinComponents(Components)}</div>`;
     }
 }
+
+export default new AppComponent;

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -26,37 +26,32 @@ export class AppComponent extends Component {
     static renderAddToDoItemAt (whereRender, state) {
         let Components = [TitleComponent.renderTitle(), TodoListComponent.renderToDoItems(state.todos)];
         let isEnabled = whereRender.next();
-        if (isEnabled.done) {
-            Components.splice(1, 0,
-                InputToDoItemComponent.renderInput(state.severities),
-            );
-        } else {
-            let indexInput;
+        let indexInput;
+        if (!isEnabled.done) {
             switch (isEnabled.value) {
                 case 'filter':
                     let indexFilter;
                     if (whereRender.next().value === 'renderBottom') {
-                        indexInput = Components.length;
-                        if (whereRender.next().value === 'filterTop') {
-                            indexFilter = 1;
-                        } else {
+                        indexInput = Components.length+1;
+                        if (whereRender.next().value !== 'filterTop') {
                             indexFilter = 2;
                         }
-
-                        Components.splice(indexFilter || 1, 0,
-                            FilterComponent.renderFilter(state.filters),
-                        );
                     }
+
+                    Components.splice(indexFilter || 1, 0,
+                        FilterComponent.renderFilter(state.filters),
+                    );
                     break;
+
                 case 'renderBottom':
                     indexInput = Components.length;
                     break;
             }
-
-            Components.splice(indexInput || 1, 0,
-                InputToDoItemComponent.renderInput(state.severities)
-            );
         }
+
+        Components.splice(indexInput || 1, 0,
+            InputToDoItemComponent.renderInput(state.severities)
+        );
 
         return `<div id="app">${AppComponent.joinComponents(Components)}</div>`;
     }

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -13,22 +13,30 @@ export default class AppComponent extends Component {
     }
 
     renderApp (el, state) {
-        this.render(el, AppComponent.renderAddToDoItemAt(isEnabled('renderBottom'), state));
+        let renderBottom = isEnabled(['renderBottom', 'filter']);
+        this.render(el, AppComponent.renderAddToDoItemAt(renderBottom, state));
     }
 
     static joinComponents (Components) {
         return Components.join('\n');
     }
 
-    static renderAddToDoItemAt (isEnabled, state) {
-        let Components = [TitleComponent.renderTitle(), FilterComponent.renderFilter(state.filters)];
-        if (isEnabled) {
+    static renderAddToDoItemAt (renderBottom, state) {
+        let Components = [TitleComponent.renderTitle()];
+        if (renderBottom.next().value) {
             Components.push(
                 TodoListComponent.renderToDoItems(state.todos),
                 InputToDoItemComponent.renderInput(state.severities)
             );
+
+            if (renderBottom.next().value) {
+                Components.push(FilterComponent.renderFilter(state.filters));
+            } else {
+                Components.splice(1, 0, FilterComponent.renderFilter(state.filters));
+            }
         } else {
             Components.push(
+                FilterComponent.renderFilter(state.filters),
                 InputToDoItemComponent.renderInput(state.severities),
                 TodoListComponent.renderToDoItems(state.todos)
             );

--- a/src/app/components/App.js
+++ b/src/app/components/App.js
@@ -32,10 +32,9 @@ export class AppComponent extends Component {
                 case 'filter':
                     let indexFilter;
                     if (whereRender.next().value === 'renderBottom') {
-                        indexInput = Components.length+1;
-                        if (whereRender.next().value !== 'filterTop') {
-                            indexFilter = 2;
-                        }
+                        indexInput = Components.length + 1;
+                        indexFilter = Components.length;
+                        if (whereRender.next().value === 'filterTop') indexFilter = 0;
                     }
 
                     Components.splice(indexFilter || 1, 0,
@@ -44,6 +43,12 @@ export class AppComponent extends Component {
                     break;
 
                 case 'renderBottom':
+                    if (whereRender.next().value === 'filter') {
+                        Components.splice(Components.length, 0,
+                            FilterComponent.renderFilter(state.filters),
+                        );
+                    }
+
                     indexInput = Components.length;
                     break;
             }

--- a/src/app/components/App.test.js
+++ b/src/app/components/App.test.js
@@ -173,6 +173,21 @@ describe('Component: AppComponent', () => {
             AppComponent.renderAddToDoItemAt(isEnabled(hashes), state);
             expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
         });
+
+        test('should be render input at bottom within filter when renderBottom and filter is enabled ', () => {
+            window.location.hash = '#renderBottom#filter';
+            let Components = [
+                TitleComponent.renderTitle(),
+                TodoListComponent.renderToDoItems(state.todos),
+                FilterComponent.renderFilter(state.filters),
+                InputToDoItemComponent.renderInput(state.severities)
+            ];
+
+            spyOn(AppComponent, 'joinComponents');
+
+            AppComponent.renderAddToDoItemAt(isEnabled(hashes), state);
+            expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
+        });
     });
 
     afterEach(() => {

--- a/src/app/components/App.test.js
+++ b/src/app/components/App.test.js
@@ -8,6 +8,7 @@ import Component from './View';
 import TitleComponent from './Title/Title';
 import InputToDoItemComponent from './Input/Input';
 import TodoListComponent from './Todo/TodoList';
+import FilterComponent from './Filter/Filter';
 import { TestingFeaturesComponent } from './TestingFeatures/TestingFeatures';
 
 //noinspection JSAnnotator
@@ -118,6 +119,51 @@ describe('Component: AppComponent', () => {
             window.location.hash = '#renderBottom';
             let Components = [
                 TitleComponent.renderTitle(),
+                TodoListComponent.renderToDoItems(state.todos),
+                InputToDoItemComponent.renderInput(state.severities)
+            ];
+
+            spyOn(AppComponent, 'joinComponents');
+
+            AppComponent.renderAddToDoItemAt(isEnabled(hashes), state);
+            expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
+        });
+
+        test('should be render filter when filter is enabled', () => {
+            window.location.hash = '#filter';
+            let Components = [
+                TitleComponent.renderTitle(),
+                InputToDoItemComponent.renderInput(state.severities),
+                FilterComponent.renderFilter(state.filters),
+                TodoListComponent.renderToDoItems(state.todos)
+            ];
+
+            spyOn(AppComponent, 'joinComponents');
+
+            AppComponent.renderAddToDoItemAt(isEnabled(hashes), state);
+            expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
+        });
+
+        test('should be render filter at bottom when filter is enabled within renderBottom', () => {
+            window.location.hash = '#filter#renderBottom';
+            let Components = [
+                TitleComponent.renderTitle(),
+                TodoListComponent.renderToDoItems(state.todos),
+                FilterComponent.renderFilter(state.filters),
+                InputToDoItemComponent.renderInput(state.severities)
+            ];
+
+            spyOn(AppComponent, 'joinComponents');
+
+            AppComponent.renderAddToDoItemAt(isEnabled(hashes), state);
+            expect(AppComponent.joinComponents).toHaveBeenCalledWith(Components);
+        });
+
+        test('should be render filter at top when filter is enabled to the top within renderBottom', () => {
+            window.location.hash = '#filter#renderBottom#filterTop';
+            let Components = [
+                TitleComponent.renderTitle(),
+                FilterComponent.renderFilter(state.filters),
                 TodoListComponent.renderToDoItems(state.todos),
                 InputToDoItemComponent.renderInput(state.severities)
             ];

--- a/src/app/components/Input/Input.styles.js
+++ b/src/app/components/Input/Input.styles.js
@@ -6,13 +6,7 @@ export const StylesInputToDoItemComponent = {
         display: 'flex',
         margin: '0',
         padding: '10px',
-        transition: 'border 0.3s 0.15s ease-in-out',
-        ':active': {
-            borderBottom: '1px solid rgb(192, 192, 192)'
-        },
-        ':focus': {
-            borderBottom: '1px solid rgb(192, 192, 192)'
-        }
+        transition: 'border 0.3s 0.15s ease-in-out'
     },
     inputButtonAddInputText: {
         textTransform: 'uppercase',

--- a/src/app/components/TestingFeatures/TestingFeatures.js
+++ b/src/app/components/TestingFeatures/TestingFeatures.js
@@ -1,0 +1,16 @@
+import AppComponent from '../App';
+
+export class TestingFeaturesComponent {
+    static windowHashChange (element, state) {
+        window.addEventListener('hashchange', (event) => {
+            AppComponent.renderApp(element, state);
+            event.stopImmediatePropagation();
+        });
+    }
+
+    static renderComponentAfterTitleComponent () {
+
+    }
+}
+
+export default new TestingFeaturesComponent;

--- a/src/app/components/TestingFeatures/TestingFeatures.js
+++ b/src/app/components/TestingFeatures/TestingFeatures.js
@@ -7,10 +7,6 @@ export class TestingFeaturesComponent {
             event.stopImmediatePropagation();
         });
     }
-
-    static renderComponentAfterTitleComponent () {
-
-    }
 }
 
 export default new TestingFeaturesComponent;

--- a/src/app/components/TestingFeatures/TestingFeatures.test.js
+++ b/src/app/components/TestingFeatures/TestingFeatures.test.js
@@ -34,14 +34,4 @@ describe('Component: TestingFeatures', () => {
             AphroditeStyles.after();
         });
     });
-
-    describe('static renderComponentAfterTitleComponent', () => {
-        test('should get static method from component', () => {
-            expect(TestingFeaturesComponent.renderComponentAfterTitleComponent).toBeDefined();
-            expect(typeof TestingFeaturesComponent.renderComponentAfterTitleComponent).toBe('function');
-        });
-
-        test('should getter components and render them after title component', () => {
-        });
-    });
 });

--- a/src/app/components/TestingFeatures/TestingFeatures.test.js
+++ b/src/app/components/TestingFeatures/TestingFeatures.test.js
@@ -1,0 +1,47 @@
+import { AphroditeStyles, event, window, document, state } from '../components.mock';
+
+import AppComponent from '../App';
+import { TestingFeaturesComponent } from './TestingFeatures';
+
+//noinspection JSAnnotator
+global.document = document;
+//noinspection JSAnnotator
+global.window = window;
+
+describe('Component: TestingFeatures', () => {
+    test('should be imported', () => {
+        expect(TestingFeaturesComponent).toBeDefined();
+        // expect(TestingFeatures).toBeDefined();
+    });
+
+    describe('static windowHashChange () =>', () => {
+        test('should update app components when window hash change', async () => {
+            let element = {};
+            AphroditeStyles.before();
+
+            spyOn(event, 'stopImmediatePropagation');
+            spyOn(AppComponent, 'renderApp').and.callFake((element, state) => {
+                return {
+                    element,
+                    state
+                }
+            });
+
+            TestingFeaturesComponent.windowHashChange(element, state);
+
+            expect(AppComponent.renderApp).toHaveBeenCalledWith(element, state);
+            expect(event.stopImmediatePropagation).toHaveBeenCalled();
+            AphroditeStyles.after();
+        });
+    });
+
+    describe('static renderComponentAfterTitleComponent', () => {
+        test('should get static method from component', () => {
+            expect(TestingFeaturesComponent.renderComponentAfterTitleComponent).toBeDefined();
+            expect(typeof TestingFeaturesComponent.renderComponentAfterTitleComponent).toBe('function');
+        });
+
+        test('should getter components and render them after title component', () => {
+        });
+    });
+});

--- a/src/app/components/components.mock.js
+++ b/src/app/components/components.mock.js
@@ -83,15 +83,15 @@ export const fetch = (url, params) => {
 
 export const state = {
     todos: [
-        { id: 0, text: 'Take a look at the application', done: true },
-        { id: 1, text: 'Add ability to filter todos', done: false },
-        { id: 2, text: 'Filter todos by status', done: false },
-        { id: 3, text: 'Filter todos by text', done: false }
+        { id: 0, text: 'Take a look at the application', done: true, severity: 'urgent' },
+        { id: 1, text: 'Add ability to filter todos', done: false, severity: 'important' },
+        { id: 2, text: 'Filter todos by status', done: false, severity: 'normal' },
+        { id: 3, text: 'Filter todos by text', done: false, severity: 'normal' }
     ],
     filters: [
         { id: 1, name: 'Mostrar ToDos', selected: true, value: null },
         { id: 2, name: 'Somente abertos', selected: false, value: false},
-        { id: 3, name: 'Somente fechados', selected: true }
+        { id: 3, name: 'Somente fechados', selected: true, value: true }
     ],
     severities: [
         { id: 1, priority: 'urgent', selected: false},

--- a/src/app/components/components.mock.js
+++ b/src/app/components/components.mock.js
@@ -125,20 +125,22 @@ const ELEMENT = {
 };
 
 export const window = {
+    addEventListener: (eventName, listener) => ELEMENT.addEventListener(eventName, listener),
     location: {
-        hash: '#renderBottom'
+        hash: '#'
     }
 };
 
 export const document = {
     body: ELEMENT,
-    ELEMENT
+    getElementById: ELEMENT.getElementById
 };
 
 export const event = {
     target: ELEMENT,
     stopPropagation: () => {},
     preventDefault: () => {},
+    stopImmediatePropagation: () => {},
     which: 13,
     key: 'Enter'
 };

--- a/src/app/lib/feature.js
+++ b/src/app/lib/feature.js
@@ -1,9 +1,8 @@
 export function *isEnabled (names) {
     let hashes = window.location.hash.split('#');
     hashes.splice(0, 1);
-    for (let index in names) {
-        if (names.hasOwnProperty(index)) {
-            yield hashes[index] === names[index];
-        }
+    for (let hash of hashes) {
+        let isEnabled = names.filter(name => name === hash).map(name => name === hash)[0];
+        if (isEnabled) yield hash
     }
 }

--- a/src/app/lib/feature.js
+++ b/src/app/lib/feature.js
@@ -1,3 +1,9 @@
-export const isEnabled = (name) => {
-    return window.location.hash.split('#')[1] === name;
-};
+export function *isEnabled (names) {
+    let hashes = window.location.hash.split('#');
+    hashes.splice(0, 1);
+    for (let index in names) {
+        if (names.hasOwnProperty(index)) {
+            yield hashes[index] === names[index];
+        }
+    }
+}

--- a/src/app/lib/feature.js
+++ b/src/app/lib/feature.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 export function *isEnabled (names) {
     let hashes = window.location.hash.split('#');
     hashes.splice(0, 1);

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -4,12 +4,11 @@ import { registerEventHandlers } from './events';
 import AppComponent from './components/App';
 
 const root = document.getElementById('root');
-const App = new AppComponent();
 
 getInitialState()
     .then(() => {
-        App.renderApp(root, store.getState());
+        AppComponent.renderApp(root, store.getState());
 
-        store.subscribe(newState => App.renderApp(root, newState));
+        store.subscribe(newState => AppComponent.renderApp(root, newState));
         registerEventHandlers();
     });


### PR DESCRIPTION
## #42 Adicione um TESTE para mudar a posição do filtro

Descobrimos que para usuários que tem o teste `renderBottom` habilitado, ficou difícil
utilizar o filtro. Nossos especialistas UX entendem que quando os dois testes estão
habilitados `#renderBottom#filter`, a parte de baixo da interface fica sobrecarregada.

Nós gostaríamos de testar a posição do filtro no topo da interface, quando o input
está posicionado na posição de baixo na aplicação (`renderBottom`).

Este teste, pode se chamar "filterTop" e só pode ser ativado quando os testes `filter` e `renderBottom`
estão ativos também. A hash da URL deve estar mais ou menos assim `index.html#filter#renderBottom#filterTop`.